### PR TITLE
Upgrade to `apollo-server-cloudflare@2.21` and mock 'tls' and 'net' modules.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,10 +25,40 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.28",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-          "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
+          "version": "10.17.54",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.54.tgz",
+          "integrity": "sha512-c8Lm7+hXdSPmWH4B9z/P/xIXhFK3mCQin4yCYMd2p1qpMG5AfgyJuYZ+3q2dT7qLiMMMGMd5dnkFpdqJARlvtQ=="
         }
+      }
+    },
+    "@apollographql/apollo-tools": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.9.tgz",
+      "integrity": "sha512-M50pk8oo3CGTu4waGOklIX3YtTZoPfWG9K/G9WB8NpyQGA1OwYTiBFv94XqUtKElTDoFwoMXpMQd3Wy5dINvxA==",
+      "requires": {
+        "apollo-env": "^0.6.6"
+      }
+    },
+    "@apollographql/graphql-playground-html": {
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.26.tgz",
+      "integrity": "sha512-XAwXOIab51QyhBxnxySdK3nuMEUohhDsHQ5Rbco/V1vjlP75zZ0ZLHD9dTpXTN8uxKxopb2lUvJTq+M4g2Q0HQ==",
+      "requires": {
+        "xss": "^1.0.6"
+      }
+    },
+    "@apollographql/graphql-upload-8-fork": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-upload-8-fork/-/graphql-upload-8-fork-8.1.3.tgz",
+      "integrity": "sha512-ssOPUT7euLqDXcdVv3Qs4LoL4BPtfermW1IOouaqEmj36TpHYDmYDIbKoSQxikd9vtMumFnP87OybH7sC9fJ6g==",
+      "requires": {
+        "@types/express": "*",
+        "@types/fs-capacitor": "*",
+        "@types/koa": "*",
+        "busboy": "^0.3.1",
+        "fs-capacitor": "^2.0.4",
+        "http-errors": "^1.7.3",
+        "object-path": "^0.11.4"
       }
     },
     "@protobufjs/aspromise": {
@@ -103,9 +133,9 @@
       }
     },
     "@types/connect": {
-      "version": "3.4.33",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
-      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
+      "version": "3.4.34",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
+      "integrity": "sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -116,9 +146,9 @@
       "integrity": "sha512-P1bffQfhD3O4LW0ioENXUhZ9OIa0Zn+P7M+pWgkCKaT53wVLSq0mrKksCID/FGHpFhRSxRGhgrQmfhRuzwtKdg=="
     },
     "@types/cookies": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.4.tgz",
-      "integrity": "sha512-oTGtMzZZAVuEjTwCjIh8T8FrC8n/uwy+PG0yTvQcdZ7etoel7C7/3MSd7qrukENTgQtotG7gvBlBojuVs7X5rw==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.6.tgz",
+      "integrity": "sha512-FK4U5Qyn7/Sc5ih233OuHO0qAkOpEcD/eG6584yEiLKizTFRny86qHLe/rej3HFQrkBuUjF4whFliAdODbVN/w==",
       "requires": {
         "@types/connect": "*",
         "@types/express": "*",
@@ -127,20 +157,20 @@
       }
     },
     "@types/express": {
-      "version": "4.17.7",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.7.tgz",
-      "integrity": "sha512-dCOT5lcmV/uC2J9k0rPafATeeyz+99xTt54ReX11/LObZgfzJqZNcW27zGhYyX+9iSEGXGt5qLPwRSvBZcLvtQ==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.11.tgz",
+      "integrity": "sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==",
       "requires": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
+        "@types/express-serve-static-core": "^4.17.18",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.9",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.9.tgz",
-      "integrity": "sha512-DG0BYg6yO+ePW+XoDENYz8zhNGC3jDDEpComMYn7WJc4mY1Us8Rw9ax2YhJXxpyk2SF47PQAoQ0YyVT1a0bEkA==",
+      "version": "4.17.18",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.18.tgz",
+      "integrity": "sha512-m4JTwx5RUBNZvky/JJ8swEJPKFd8si08pPF2PfizYjGZOKr/svUWPcoUmLow6MmPzhasphB7gSTINY67xn3JNA==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -153,17 +183,6 @@
       "integrity": "sha512-FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==",
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/graphql-upload": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@types/graphql-upload/-/graphql-upload-8.0.3.tgz",
-      "integrity": "sha512-hmLg9pCU/GmxBscg8GCr1vmSoEmbItNNxdD5YH2TJkXm//8atjwuprB+xJBK714JG1dkxbbhp5RHX+Pz1KsCMA==",
-      "requires": {
-        "@types/express": "*",
-        "@types/fs-capacitor": "*",
-        "@types/koa": "*",
-        "graphql": "^14.5.3"
       }
     },
     "@types/http-assert": {
@@ -182,9 +201,9 @@
       "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
     },
     "@types/koa": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.11.4.tgz",
-      "integrity": "sha512-Etqs0kdqbuAsNr5k6mlZQelpZKVwMu9WPRHVVTLnceZlhr0pYmblRNJbCgoCMzKWWePldydU0AYEOX4Q9fnGUQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.0.tgz",
+      "integrity": "sha512-hNs1Z2lX+R5sZroIy/WIGbPlH/719s/Nd5uIjSIAdHn9q+g7z6mxOnhwMjK1urE4/NUP0SOoYUOD4MnvD9FRNw==",
       "requires": {
         "@types/accepts": "*",
         "@types/content-disposition": "*",
@@ -205,19 +224,19 @@
       }
     },
     "@types/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/mime": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
-      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "@types/node": {
-      "version": "11.13.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.8.tgz",
-      "integrity": "sha512-szA3x/3miL90ZJxUCzx9haNbK5/zmPieGraZEe4WI+3srN0eGLiT22NXeMHmyhNEopn+IrxqMc7wdVwvPl8meg=="
+      "version": "14.14.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
     },
     "@types/node-fetch": {
       "version": "2.5.7",
@@ -229,9 +248,9 @@
       }
     },
     "@types/qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ=="
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
+      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -239,12 +258,48 @@
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/serve-static": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.5.tgz",
-      "integrity": "sha512-6M64P58N+OXjU432WoLLBQxbA0LRGBCRm7aAGQJ+SMC1IMl0dgRVi9EFfoDcS2a7Xogygk/eGN94CfwU9UF7UQ==",
+      "version": "1.13.9",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.9.tgz",
+      "integrity": "sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==",
       "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "@types/ws": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.0.tgz",
+      "integrity": "sha512-Y29uQ3Uy+58bZrFLhX36hcI3Np37nqWE7ky5tjiDoy1GDZnIwVxS0CgF+s+1bXMzjKBFy+fqaRfb708iNzdinw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@wry/equality": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
+      "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "apollo-cache-control": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.11.6.tgz",
+      "integrity": "sha512-YZ+uuIG+fPy+mkpBS2qKF0v1qlzZ3PW6xZVaDukeK3ed3iAs4L/2YnkTqau3OmoF/VPzX2FmSkocX/OVd59YSw==",
+      "requires": {
+        "apollo-server-env": "^3.0.0",
+        "apollo-server-plugin-base": "^0.10.4"
+      },
+      "dependencies": {
+        "apollo-server-env": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.0.0.tgz",
+          "integrity": "sha512-tPSN+VttnPsoQAl/SBVUpGbLA97MXG990XIwq6YUnJyAixrrsjW1xYG7RlaOqetxm80y5mBZKLrRDiiSsW/vog==",
+          "requires": {
+            "node-fetch": "^2.1.2",
+            "util.promisify": "^1.0.0"
+          }
+        }
       }
     },
     "apollo-datasource": {
@@ -268,15 +323,43 @@
         "http-cache-semantics": "^4.0.0"
       }
     },
-    "apollo-link": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.11.tgz",
-      "integrity": "sha512-PQvRCg13VduLy3X/0L79M6uOpTh5iHdxnxYuo8yL7sJlWybKRJwsv4IcRBJpMFbChOOaHY7Og9wgPo6DLKDKDA==",
+    "apollo-env": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.6.tgz",
+      "integrity": "sha512-hXI9PjJtzmD34XviBU+4sPMOxnifYrHVmxpjykqI/dUD2G3yTiuRaiQqwRwB2RCdwC1Ug/jBfoQ/NHDTnnjndQ==",
       "requires": {
-        "apollo-utilities": "^1.2.1",
-        "ts-invariant": "^0.3.2",
+        "@types/node-fetch": "2.5.7",
+        "core-js": "^3.0.1",
+        "node-fetch": "^2.2.0",
+        "sha.js": "^2.4.11"
+      }
+    },
+    "apollo-graphql": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.6.1.tgz",
+      "integrity": "sha512-ZRXAV+k+hboCVS+FW86FW/QgnDR7gm/xMUwJPGXEbV53OLGuQQdIT0NCYK7AzzVkCfsbb7NJ3mmEclkZY9uuxQ==",
+      "requires": {
+        "apollo-env": "^0.6.6",
+        "lodash.sortby": "^4.7.0"
+      }
+    },
+    "apollo-link": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+      "requires": {
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.18"
+        "zen-observable-ts": "^0.8.21"
+      }
+    },
+    "apollo-reporting-protobuf": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.6.2.tgz",
+      "integrity": "sha512-WJTJxLM+MRHNUxt1RTl4zD0HrLdH44F2mDzMweBj1yHL0kSt8I1WwoiF/wiGVSpnG48LZrBegCaOJeuVbJTbtw==",
+      "requires": {
+        "@apollo/protobufjs": "^1.0.3"
       }
     },
     "apollo-server-caching": {
@@ -288,142 +371,79 @@
       }
     },
     "apollo-server-cloudflare": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-cloudflare/-/apollo-server-cloudflare-2.16.1.tgz",
-      "integrity": "sha512-ceL0ef+TPJOsR0VA0eGfamoksp4CP9gyfRjdW0yqMQ3Ssvh+G6Ryq9BP2RSA8qsebuTq1GcgD2ROx3Sd09QcHw==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-cloudflare/-/apollo-server-cloudflare-2.21.0.tgz",
+      "integrity": "sha512-hDSKMUTZDn9D6+fNkWS7D8j5+++t8dJAWfd6BE3ur6YU9uym6NpmFXHlcGjs2Oc65r2WmM1libu4v7sSiIQv5g==",
       "requires": {
-        "apollo-server-core": "^2.16.1",
-        "apollo-server-env": "^2.4.5",
-        "apollo-server-types": "^0.5.1"
+        "apollo-server-core": "^2.21.0",
+        "apollo-server-env": "^3.0.0",
+        "apollo-server-types": "^0.6.3"
       },
       "dependencies": {
-        "@apollographql/apollo-tools": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.8.tgz",
-          "integrity": "sha512-W2+HB8Y7ifowcf3YyPHgDI05izyRtOeZ4MqIr7LbTArtmJ0ZHULWpn84SGMW7NAvTV1tFExpHlveHhnXuJfuGA==",
+        "apollo-server-env": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.0.0.tgz",
+          "integrity": "sha512-tPSN+VttnPsoQAl/SBVUpGbLA97MXG990XIwq6YUnJyAixrrsjW1xYG7RlaOqetxm80y5mBZKLrRDiiSsW/vog==",
           "requires": {
-            "apollo-env": "^0.6.5"
+            "node-fetch": "^2.1.2",
+            "util.promisify": "^1.0.0"
           }
-        },
-        "@apollographql/graphql-playground-html": {
-          "version": "1.6.26",
-          "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.26.tgz",
-          "integrity": "sha512-XAwXOIab51QyhBxnxySdK3nuMEUohhDsHQ5Rbco/V1vjlP75zZ0ZLHD9dTpXTN8uxKxopb2lUvJTq+M4g2Q0HQ==",
-          "requires": {
-            "xss": "^1.0.6"
-          }
-        },
-        "@types/ws": {
-          "version": "7.2.6",
-          "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.6.tgz",
-          "integrity": "sha512-Q07IrQUSNpr+cXU4E4LtkSIBPie5GLZyyMC1QtQYRLWz701+XcoVygGUZgvLqElq1nU4ICldMYPnexlBsg3dqQ==",
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "apollo-cache-control": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.11.1.tgz",
-          "integrity": "sha512-6iHa8TkcKt4rx5SKRzDNjUIpCQX+7/FlZwD7vRh9JDnM4VH8SWhpj8fUR3CiEY8Kuc4ChXnOY8bCcMju5KPnIQ==",
-          "requires": {
-            "apollo-server-env": "^2.4.5",
-            "apollo-server-plugin-base": "^0.9.1"
-          }
-        },
+        }
+      }
+    },
+    "apollo-server-core": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.21.0.tgz",
+      "integrity": "sha512-GtIiq2F0dVDLzzIuO5+dK/pGq/sGxYlKCqAuQQqzYg0fvZ7fukyluXtcTe0tMI+FJZjU0j0WnKgiLsboCoAlPQ==",
+      "requires": {
+        "@apollographql/apollo-tools": "^0.4.3",
+        "@apollographql/graphql-playground-html": "1.6.26",
+        "@apollographql/graphql-upload-8-fork": "^8.1.3",
+        "@types/ws": "^7.0.0",
+        "apollo-cache-control": "^0.11.6",
+        "apollo-datasource": "^0.7.3",
+        "apollo-graphql": "^0.6.0",
+        "apollo-reporting-protobuf": "^0.6.2",
+        "apollo-server-caching": "^0.5.3",
+        "apollo-server-env": "^3.0.0",
+        "apollo-server-errors": "^2.4.2",
+        "apollo-server-plugin-base": "^0.10.4",
+        "apollo-server-types": "^0.6.3",
+        "apollo-tracing": "^0.12.2",
+        "async-retry": "^1.2.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-extensions": "^0.12.8",
+        "graphql-tag": "^2.11.0",
+        "graphql-tools": "^4.0.8",
+        "loglevel": "^1.6.7",
+        "lru-cache": "^6.0.0",
+        "sha.js": "^2.4.11",
+        "subscriptions-transport-ws": "^0.9.11",
+        "uuid": "^8.0.0",
+        "ws": "^6.0.0"
+      },
+      "dependencies": {
         "apollo-datasource": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.7.2.tgz",
-          "integrity": "sha512-ibnW+s4BMp4K2AgzLEtvzkjg7dJgCaw9M5b5N0YKNmeRZRnl/I/qBTQae648FsRKgMwTbRQIvBhQ0URUFAqFOw==",
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.7.3.tgz",
+          "integrity": "sha512-PE0ucdZYjHjUyXrFWRwT02yLcx2DACsZ0jm1Mp/0m/I9nZu/fEkvJxfsryXB6JndpmQO77gQHixf/xGCN976kA==",
           "requires": {
-            "apollo-server-caching": "^0.5.2",
-            "apollo-server-env": "^2.4.5"
-          }
-        },
-        "apollo-engine-reporting": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-2.3.0.tgz",
-          "integrity": "sha512-SbcPLFuUZcRqDEZ6mSs8uHM9Ftr8yyt2IEu0JA8c3LNBmYXSLM7MHqFe80SVcosYSTBgtMz8mLJO8orhYoSYZw==",
-          "requires": {
-            "apollo-engine-reporting-protobuf": "^0.5.2",
-            "apollo-graphql": "^0.5.0",
-            "apollo-server-caching": "^0.5.2",
-            "apollo-server-env": "^2.4.5",
-            "apollo-server-errors": "^2.4.2",
-            "apollo-server-plugin-base": "^0.9.1",
-            "apollo-server-types": "^0.5.1",
-            "async-retry": "^1.2.1",
-            "uuid": "^8.0.0"
-          }
-        },
-        "apollo-engine-reporting-protobuf": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.5.2.tgz",
-          "integrity": "sha512-4wm9FR3B7UvJxcK/69rOiS5CAJPEYKufeRWb257ZLfX7NGFTMqvbc1hu4q8Ch7swB26rTpkzfsftLED9DqH9qg==",
-          "requires": {
-            "@apollo/protobufjs": "^1.0.3"
-          }
-        },
-        "apollo-env": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.5.tgz",
-          "integrity": "sha512-jeBUVsGymeTHYWp3me0R2CZRZrFeuSZeICZHCeRflHTfnQtlmbSXdy5E0pOyRM9CU4JfQkKDC98S1YglQj7Bzg==",
-          "requires": {
-            "@types/node-fetch": "2.5.7",
-            "core-js": "^3.0.1",
-            "node-fetch": "^2.2.0",
-            "sha.js": "^2.4.11"
-          }
-        },
-        "apollo-graphql": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.5.0.tgz",
-          "integrity": "sha512-YSdF/BKPbsnQpxWpmCE53pBJX44aaoif31Y22I/qKpB6ZSGzYijV5YBoCL5Q15H2oA/v/02Oazh9lbp4ek3eig==",
-          "requires": {
-            "apollo-env": "^0.6.5",
-            "lodash.sortby": "^4.7.0"
+            "apollo-server-caching": "^0.5.3",
+            "apollo-server-env": "^3.0.0"
           }
         },
         "apollo-server-caching": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.2.tgz",
-          "integrity": "sha512-HUcP3TlgRsuGgeTOn8QMbkdx0hLPXyEJehZIPrcof0ATz7j7aTPA4at7gaiFHCo8gk07DaWYGB3PFgjboXRcWQ==",
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.3.tgz",
+          "integrity": "sha512-iMi3087iphDAI0U2iSBE9qtx9kQoMMEWr6w+LwXruBD95ek9DWyj7OeC2U/ngLjRsXM43DoBDXlu7R+uMjahrQ==",
           "requires": {
-            "lru-cache": "^5.0.0"
-          }
-        },
-        "apollo-server-core": {
-          "version": "2.16.1",
-          "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.16.1.tgz",
-          "integrity": "sha512-nuwn5ZBbmzPwDetb3FgiFFJlNK7ZBFg8kis/raymrjd3eBGdNcOyMTJDl6J9673X9Xqp+dXQmFYDW/G3G8S1YA==",
-          "requires": {
-            "@apollographql/apollo-tools": "^0.4.3",
-            "@apollographql/graphql-playground-html": "1.6.26",
-            "@types/graphql-upload": "^8.0.0",
-            "@types/ws": "^7.0.0",
-            "apollo-cache-control": "^0.11.1",
-            "apollo-datasource": "^0.7.2",
-            "apollo-engine-reporting": "^2.3.0",
-            "apollo-server-caching": "^0.5.2",
-            "apollo-server-env": "^2.4.5",
-            "apollo-server-errors": "^2.4.2",
-            "apollo-server-plugin-base": "^0.9.1",
-            "apollo-server-types": "^0.5.1",
-            "apollo-tracing": "^0.11.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "graphql-extensions": "^0.12.4",
-            "graphql-tag": "^2.9.2",
-            "graphql-tools": "^4.0.0",
-            "graphql-upload": "^8.0.2",
-            "loglevel": "^1.6.7",
-            "sha.js": "^2.4.11",
-            "subscriptions-transport-ws": "^0.9.11",
-            "ws": "^6.0.0"
+            "lru-cache": "^6.0.0"
           }
         },
         "apollo-server-env": {
-          "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.5.tgz",
-          "integrity": "sha512-nfNhmGPzbq3xCEWT8eRpoHXIPNcNy3QcEoBlzVMjeglrBGryLG2LXwBSPnVmTRRrzUYugX0ULBtgE3rBFNoUgA==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.0.0.tgz",
+          "integrity": "sha512-tPSN+VttnPsoQAl/SBVUpGbLA97MXG990XIwq6YUnJyAixrrsjW1xYG7RlaOqetxm80y5mBZKLrRDiiSsW/vog==",
           "requires": {
             "node-fetch": "^2.1.2",
             "util.promisify": "^1.0.0"
@@ -434,42 +454,18 @@
           "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.2.tgz",
           "integrity": "sha512-FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ=="
         },
-        "apollo-server-plugin-base": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.9.1.tgz",
-          "integrity": "sha512-kvrX4Z3FdpjrZdHkyl5iY2A1Wvp4b6KQp00DeZqss7GyyKNUBKr80/7RQgBLEw7EWM7WB19j459xM/TjvW0FKQ==",
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "requires": {
-            "apollo-server-types": "^0.5.1"
+            "yallist": "^4.0.0"
           }
         },
-        "apollo-tracing": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.11.1.tgz",
-          "integrity": "sha512-l7g+uILw7v32GA46IRXIx5XXbZhFI96BhSqrGK9yyvfq+NMcvVZrj3kIhRImPGhAjMdV+5biA/jztabElAbDjg==",
-          "requires": {
-            "apollo-server-env": "^2.4.5",
-            "apollo-server-plugin-base": "^0.9.1"
-          }
-        },
-        "core-js": {
-          "version": "3.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
-        },
-        "graphql-extensions": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.12.4.tgz",
-          "integrity": "sha512-GnR4LiWk3s2bGOqIh6V1JgnSXw2RCH4NOgbCFEWvB6JqWHXTlXnLZ8bRSkCiD4pltv7RHUPWqN/sGh8R6Ae/ag==",
-          "requires": {
-            "@apollographql/apollo-tools": "^0.4.3",
-            "apollo-server-env": "^2.4.5",
-            "apollo-server-types": "^0.5.1"
-          }
-        },
-        "uuid": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -487,36 +483,69 @@
       "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.2.1.tgz",
       "integrity": "sha512-wY/YE3iJVMYC+WYIf8QODBjIP4jhI+oc7kiYo9mrz7LdYPKAgxr/he+NteGcqn/0Ea9K5/ZFTGJDbEstSMeP8g=="
     },
-    "apollo-server-types": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.5.1.tgz",
-      "integrity": "sha512-my2cPw+DAb2qVnIuBcsRKGyS28uIc2vjFxa1NpRoJZe9gK0BWUBk7wzXnIzWy3HZ5Er11e/40MPTUesNfMYNVA==",
+    "apollo-server-plugin-base": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.10.4.tgz",
+      "integrity": "sha512-HRhbyHgHFTLP0ImubQObYhSgpmVH4Rk1BinnceZmwudIVLKrqayIVOELdyext/QnSmmzg5W7vF3NLGBcVGMqDg==",
       "requires": {
-        "apollo-engine-reporting-protobuf": "^0.5.2",
-        "apollo-server-caching": "^0.5.2",
-        "apollo-server-env": "^2.4.5"
+        "apollo-server-types": "^0.6.3"
+      }
+    },
+    "apollo-server-types": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.6.3.tgz",
+      "integrity": "sha512-aVR7SlSGGY41E1f11YYz5bvwA89uGmkVUtzMiklDhZ7IgRJhysT5Dflt5IuwDxp+NdQkIhVCErUXakopocFLAg==",
+      "requires": {
+        "apollo-reporting-protobuf": "^0.6.2",
+        "apollo-server-caching": "^0.5.3",
+        "apollo-server-env": "^3.0.0"
       },
       "dependencies": {
-        "apollo-engine-reporting-protobuf": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.5.2.tgz",
-          "integrity": "sha512-4wm9FR3B7UvJxcK/69rOiS5CAJPEYKufeRWb257ZLfX7NGFTMqvbc1hu4q8Ch7swB26rTpkzfsftLED9DqH9qg==",
-          "requires": {
-            "@apollo/protobufjs": "^1.0.3"
-          }
-        },
         "apollo-server-caching": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.2.tgz",
-          "integrity": "sha512-HUcP3TlgRsuGgeTOn8QMbkdx0hLPXyEJehZIPrcof0ATz7j7aTPA4at7gaiFHCo8gk07DaWYGB3PFgjboXRcWQ==",
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.5.3.tgz",
+          "integrity": "sha512-iMi3087iphDAI0U2iSBE9qtx9kQoMMEWr6w+LwXruBD95ek9DWyj7OeC2U/ngLjRsXM43DoBDXlu7R+uMjahrQ==",
           "requires": {
-            "lru-cache": "^5.0.0"
+            "lru-cache": "^6.0.0"
           }
         },
         "apollo-server-env": {
-          "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.5.tgz",
-          "integrity": "sha512-nfNhmGPzbq3xCEWT8eRpoHXIPNcNy3QcEoBlzVMjeglrBGryLG2LXwBSPnVmTRRrzUYugX0ULBtgE3rBFNoUgA==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.0.0.tgz",
+          "integrity": "sha512-tPSN+VttnPsoQAl/SBVUpGbLA97MXG990XIwq6YUnJyAixrrsjW1xYG7RlaOqetxm80y5mBZKLrRDiiSsW/vog==",
+          "requires": {
+            "node-fetch": "^2.1.2",
+            "util.promisify": "^1.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "apollo-tracing": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.12.2.tgz",
+      "integrity": "sha512-SYN4o0C0wR1fyS3+P0FthyvsQVHFopdmN3IU64IaspR/RZScPxZ3Ae8uu++fTvkQflAkglnFM0aX6DkZERBp6w==",
+      "requires": {
+        "apollo-server-env": "^3.0.0",
+        "apollo-server-plugin-base": "^0.10.4"
+      },
+      "dependencies": {
+        "apollo-server-env": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.0.0.tgz",
+          "integrity": "sha512-tPSN+VttnPsoQAl/SBVUpGbLA97MXG990XIwq6YUnJyAixrrsjW1xYG7RlaOqetxm80y5mBZKLrRDiiSsW/vog==",
           "requires": {
             "node-fetch": "^2.1.2",
             "util.promisify": "^1.0.0"
@@ -525,34 +554,25 @@
       }
     },
     "apollo-utilities": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.2.1.tgz",
-      "integrity": "sha512-Zv8Udp9XTSFiN8oyXOjf6PMHepD4yxxReLsl6dPUy5Ths7jti3nmlBzZUOxuTWRwZn0MoclqL7RQ5UEJN8MAxg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
+      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
       "requires": {
+        "@wry/equality": "^0.1.2",
         "fast-json-stable-stringify": "^2.0.0",
-        "ts-invariant": "^0.2.1",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "ts-invariant": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.2.1.tgz",
-          "integrity": "sha512-Z/JSxzVmhTo50I+LKagEISFJW3pvPCqsMWLamCTX8Kr3N5aMrnGOqcflbe5hLUzwjvgPfnLzQtHZv0yWQ+FIHg==",
-          "requires": {
-            "tslib": "^1.9.3"
-          }
-        }
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
       }
     },
     "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "async-retry": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.2.3.tgz",
-      "integrity": "sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
+      "integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
       "requires": {
         "retry": "0.12.0"
       }
@@ -587,6 +607,11 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "core-js": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
+      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg=="
     },
     "cssfilter": {
       "version": "0.0.10",
@@ -653,14 +678,14 @@
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "form-data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -668,9 +693,9 @@
       }
     },
     "fs-capacitor": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-2.0.1.tgz",
-      "integrity": "sha512-kyV2oaG1/pu9NPosfGACmBym6okgzyg6hEtA5LSUq0dGpGLe278MVfMwVnSHDA/OBcTCHkPNqWL9eIwbPN6dDg=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-2.0.4.tgz",
+      "integrity": "sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA=="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -685,32 +710,49 @@
         "iterall": "^1.2.2"
       }
     },
+    "graphql-extensions": {
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.12.8.tgz",
+      "integrity": "sha512-xjsSaB6yKt9jarFNNdivl2VOx52WySYhxPgf8Y16g6GKZyAzBoIFiwyGw5PJDlOSUa6cpmzn6o7z8fVMbSAbkg==",
+      "requires": {
+        "@apollographql/apollo-tools": "^0.4.3",
+        "apollo-server-env": "^3.0.0",
+        "apollo-server-types": "^0.6.3"
+      },
+      "dependencies": {
+        "apollo-server-env": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.0.0.tgz",
+          "integrity": "sha512-tPSN+VttnPsoQAl/SBVUpGbLA97MXG990XIwq6YUnJyAixrrsjW1xYG7RlaOqetxm80y5mBZKLrRDiiSsW/vog==",
+          "requires": {
+            "node-fetch": "^2.1.2",
+            "util.promisify": "^1.0.0"
+          }
+        }
+      }
+    },
     "graphql-tag": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz",
-      "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg=="
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
+      "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
     },
     "graphql-tools": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.4.tgz",
-      "integrity": "sha512-chF12etTIGVVGy3fCTJ1ivJX2KB7OSG4c6UOJQuqOHCmBQwTyNgCDuejZKvpYxNZiEx7bwIjrodDgDe9RIkjlw==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.8.tgz",
+      "integrity": "sha512-MW+ioleBrwhRjalKjYaLQbr+920pHBgy9vM/n47sswtns8+96sRn5M/G+J1eu7IMeKWiN/9p6tmwCHU7552VJg==",
       "requires": {
-        "apollo-link": "^1.2.3",
+        "apollo-link": "^1.2.14",
         "apollo-utilities": "^1.0.1",
         "deprecated-decorator": "^0.1.6",
         "iterall": "^1.1.3",
         "uuid": "^3.1.0"
-      }
-    },
-    "graphql-upload": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.0.6.tgz",
-      "integrity": "sha512-cBRALMOvGBm2AD6M61b1QbSmKfCLXvgV+Z3wXT2JS1EQwGWQ1g5/sby4J/cpwAaGnq5P2eGp+N3HQI9cSn9Jfg==",
-      "requires": {
-        "busboy": "^0.3.1",
-        "fs-capacitor": "^2.0.1",
-        "http-errors": "^1.7.2",
-        "object-path": "^0.11.4"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "has": {
@@ -732,21 +774,21 @@
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
     "http-errors": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
+      "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
       "requires": {
         "depd": "~1.1.2",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.1.1",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "is-callable": {
       "version": "1.1.4",
@@ -785,9 +827,9 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "loglevel": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
-      "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA=="
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
+      "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw=="
     },
     "long": {
       "version": "4.0.0",
@@ -803,16 +845,16 @@
       }
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.29",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+      "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.46.0"
       }
     },
     "node-fetch": {
@@ -826,9 +868,9 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-path": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
-      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.5.tgz",
+      "integrity": "sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg=="
     },
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
@@ -845,14 +887,14 @@
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "setprototypeof": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "sha.js": {
       "version": "2.4.11",
@@ -874,9 +916,9 @@
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "subscriptions-transport-ws": {
-      "version": "0.9.16",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz",
-      "integrity": "sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==",
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.18.tgz",
+      "integrity": "sha512-tztzcBTNoEbuErsVQpTN2xUNN/efAZXyCyL5m3x4t6SKrEiTL2N8SaKWBFWM4u56pL79ULif3zjyeq+oV+nOaA==",
       "requires": {
         "backo2": "^1.0.2",
         "eventemitter3": "^3.1.0",
@@ -906,17 +948,17 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "ts-invariant": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.3.3.tgz",
-      "integrity": "sha512-UReOKsrJFGC9tUblgSRWo+BsVNbEd77Cl6WiV/XpMlkifXwNIJbknViCucHvVZkXSC/mcWeRnIGdY7uprcwvdQ==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
       "requires": {
         "tslib": "^1.9.3"
       }
     },
     "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "util.promisify": {
       "version": "1.0.0",
@@ -928,9 +970,9 @@
       }
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "ws": {
       "version": "6.2.1",
@@ -955,14 +997,14 @@
       "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     },
     "zen-observable": {
-      "version": "0.8.14",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.14.tgz",
-      "integrity": "sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g=="
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "zen-observable-ts": {
-      "version": "0.8.18",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.18.tgz",
-      "integrity": "sha512-q7d05s75Rn1j39U5Oapg3HI2wzriVwERVo4N7uFGpIYuHB9ff02P/E92P9B8T7QVC93jCMHpbXH7X0eVR5LA7A==",
+      "version": "0.8.21",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
       "requires": {
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Kristian Freeman <kristian@bytesized.xyz>",
   "dependencies": {
     "apollo-datasource-rest": "^0.3.2",
-    "apollo-server-cloudflare": "^2.16.1",
+    "apollo-server-cloudflare": "^2.21.0",
     "graphql": "^14.2.1"
   },
   "license": "MIT",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,10 @@ module.exports = {
   target: 'webworker',
   resolve: {
     alias: {
+      // While Apollo Server doesn't use the 'fs' Node.js builtin itself,
+      // its dependency - graphql-upload - does leverage it.
+      // An intention is for Apollo Server 3.x to no longer directly rely on
+      // graphql-upload, so this may be re-visited when that release occurs.
       fs: path.resolve(__dirname, './null.js'),
 
       // The 'net' and 'tls' Node.js built-in usage within Apollo Server

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,16 @@ module.exports = {
   resolve: {
     alias: {
       fs: path.resolve(__dirname, './null.js'),
+
+      // The 'net' and 'tls' Node.js built-in usage within Apollo Server
+      // is merely to run `instanceof` checks against an existing,
+      // user-supplied "server" instance when subscriptions are desired to
+      // be bound to an already-created server.  For the purposes of
+      // Cloudflare, where none of these Node.js builtins exist, this
+      // instanceof check is irrelevant because such a class could not
+      // exist.
+      net: path.resolve(__dirname, './null.js'),
+      tls: path.resolve(__dirname, './null.js'),
     },
   },
   mode: 'production',


### PR DESCRIPTION
This upgrades to Apollo Server 2.21 and makes a Webpack configuration change to make it possible to bundle that new version.

Per the comment added within the Webpack configuration which aliases the 'tls' and 'net' modules in the resulting bundle to empty modules:

The 'net' and 'tls' Node.js built-in usage within Apollo Server is merely to run `instanceof` checks against an existing, user-supplied "server" instance when subscriptions are desired to be bound to an already-created server. For the purposes of Cloudflare, where none of these Node.js builtins exist, this instanceof check is irrelevant because such a class could not exist.

This is necessary as of the introduction of those `instanceof` checks in https://github.com/apollographql/apollo-server/commit/8ab0e90724d8d35ad.